### PR TITLE
[SL-1037] - Unable to login in a desktop app

### DIFF
--- a/app/utils/browser/index.js
+++ b/app/utils/browser/index.js
@@ -20,7 +20,11 @@ if (env.NODE_ENV === 'development') {
 let analytics;
 const gaKey = config.get('integrations.ga.key');
 if (gaKey) {
-  analytics = new Analytics(gaKey);
+  try {
+    analytics = new Analytics(gaKey);
+  } catch (err) {
+    console.error('Google Analytics error:', err);
+  }
 }
 
 const createOAuth2 = ({ client_id, client_secret, access_token_url, authorize_url }) =>


### PR DESCRIPTION
I'm the only one person affected by this issue in a Stoplight team. As I figured out other people have this issues as well according to an Electron community. It is actually really rare, but it completely breaks an app because you can't login.

- Environment: Stoplight Next Desktop 
- AppPreConditions: you need to have a last version of the app installed and you must be not logged in.
- Expected Behavior: Hotkeys are working, app menu is visible, able to login.
- Actual Behavior: Hotkeys are not working, no app menu, unable to login.

This issue is caused by an electron-ga package. It is used in a app/utils/browser/index.js file. Error is thrown on creating new instance of Analytics` class. Because of this error app/utils/browser/index.js‌can not be loaded by the  BrowserWindow preload, that is why app menu, hotkeys and auth are not working.

electron-ga uses a node-machine-id packages as a dependency. node-machine-id tries to obtain env info with a command which results in an error:

```
Error: Command failed: ioreg -rd1 -c IOPlatformExpertDevice
/bin/sh: ioreg: command not found
```

BrowserWindow preload is unique because it has node and browser environments available at a same time. node-machine-id runs in a node env during preload process. Most likely error is caused by some problems in my machine configuration. Unfortunately this can not be fixed from apps side. I added an additional try/catch to prevent a preload process from breaking by this error.